### PR TITLE
Make StateBox.value public

### DIFF
--- a/Sources/StateType.swift
+++ b/Sources/StateType.swift
@@ -21,7 +21,7 @@ public protocol StateType {
 
 /// A type to box non-class `StateType`s in classes for better ObjC portability. Curretnly this is only used for test notifications (see: "On Testing" in `StateMachine.swift`).
 public class StateBox<T:StateType> {
-  let value: T
+  public let value: T
   init(value: T) {
     self.value = value
   }


### PR DESCRIPTION
So that it is readable by importers of this framework
